### PR TITLE
Added DateFormatters to the RF3339Utils class to be able to parse abitra...

### DIFF
--- a/streams-pojo/src/main/java/org/apache/streams/data/util/RFC3339Utils.java
+++ b/streams-pojo/src/main/java/org/apache/streams/data/util/RFC3339Utils.java
@@ -157,7 +157,7 @@ public class RFC3339Utils {
      * @param dateString abitrarily formatted date or date and time string
      * @return {@link org.joda.time.DateTime} representation of the dateString
      */
-    public static DateTime parseToDateTime(String dateString) {
+    public static DateTime parseToUTC(String dateString) {
         try {
             return DEFAULT_FORMATTER.parseDateTime(dateString);
         } catch (Exception e) {
@@ -171,7 +171,7 @@ public class RFC3339Utils {
      * @return RFC3339 compliant date string
      */
     public static String format(String dateString) {
-        return format(parseToDateTime(dateString));
+        return format(parseToUTC(dateString));
     }
 
     private static DateTime parseUTC(DateTimeFormatter formatter, String toParse) {

--- a/streams-pojo/src/test/java/org/apache/streams/data/data/util/RFC3339UtilsTest.java
+++ b/streams-pojo/src/test/java/org/apache/streams/data/data/util/RFC3339UtilsTest.java
@@ -205,19 +205,19 @@ public class RFC3339UtilsTest {
         testHelper(expected, date);
         date = "2014/4/24 fesdfs";
         try {
-            RFC3339Utils.parseToDateTime(date);
+            RFC3339Utils.parseToUTC(date);
             fail("Should not have been able to parse : "+date);
         } catch (Exception e) {
         }
     }
 
     private void testHelper(DateTime expected, String dateString) {
-        DateTime parsedDate = RFC3339Utils.parseToDateTime(dateString);
+        DateTime parsedDate = RFC3339Utils.parseToUTC(dateString);
         assertEquals("Failed to parse : "+dateString, expected, parsedDate);
         String rfc3339String = RFC3339Utils.format(dateString);
         String parsedRfc3339String = RFC3339Utils.format(parsedDate);
         assertEquals("Parsed String should be equal.", parsedRfc3339String, rfc3339String);
-        DateTime convertedBack = RFC3339Utils.parseToDateTime(parsedRfc3339String);
+        DateTime convertedBack = RFC3339Utils.parseToUTC(parsedRfc3339String);
         assertEquals(expected, convertedBack);
     }
 }


### PR DESCRIPTION
Added the functionality to be able to parse arbitrarily formatted Strings into DateTime objects or convert them into RFC3339 compliant Strings.
