### PR TITLE
Streams 107

### DIFF
--- a/streams-contrib/streams-provider-twitter/src/main/java/org/apache/streams/twitter/processor/TwitterProfileProcessor.java
+++ b/streams-contrib/streams-provider-twitter/src/main/java/org/apache/streams/twitter/processor/TwitterProfileProcessor.java
@@ -1,19 +1,3 @@
-/*Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.*/
 package org.apache.streams.twitter.processor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;


### PR DESCRIPTION
STREAMS-107 | Added in license header and broke out method to create a new StreamsDatum object. This way, any classes that extend TwitterProfileProcessor can override how their individual StreamsDatum objects get created (with a different ID, for example)
