### PR TITLE
this commit avoids a bug jaxb2 basics under JDK8.  some misc pom version...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
         <datastax.version>1.0.3</datastax.version>
         <jsonschema2pojo.version>0.4.5</jsonschema2pojo.version>
         <jaxb2.version>0.8.3</jaxb2.version>
-        <jaxb2-basics.version>0.6.5</jaxb2-basics.version>
+        <jaxb2-basics.version>0.8.4</jaxb2-basics.version>
         <jaxbutil.version>1.2.6</jaxbutil.version>
         <junit.version>4.11</junit.version>
         <slf4j.version>1.7.6</slf4j.version>

--- a/streams-config/pom.xml
+++ b/streams-config/pom.xml
@@ -82,7 +82,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/streams-contrib/streams-amazon-aws/streams-persist-s3/pom.xml
+++ b/streams-contrib/streams-amazon-aws/streams-persist-s3/pom.xml
@@ -59,7 +59,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/streams-contrib/streams-persist-hdfs/pom.xml
+++ b/streams-contrib/streams-persist-hdfs/pom.xml
@@ -70,7 +70,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/streams-contrib/streams-persist-kafka/pom.xml
+++ b/streams-contrib/streams-persist-kafka/pom.xml
@@ -100,7 +100,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/streams-contrib/streams-persist-mongo/pom.xml
+++ b/streams-contrib/streams-persist-mongo/pom.xml
@@ -53,7 +53,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/streams-contrib/streams-provider-datasift/pom.xml
+++ b/streams-contrib/streams-provider-datasift/pom.xml
@@ -110,7 +110,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>
@@ -159,7 +158,6 @@
                     <plugin>
                         <groupId>org.codehaus.mojo</groupId>
                         <artifactId>build-helper-maven-plugin</artifactId>
-                        <version>1.8</version>
                         <executions>
                             <execution>
                                 <id>add-test-source</id>

--- a/streams-contrib/streams-provider-facebook/pom.xml
+++ b/streams-contrib/streams-provider-facebook/pom.xml
@@ -79,7 +79,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/streams-contrib/streams-provider-gnip/gnip-edc-facebook/pom.xml
+++ b/streams-contrib/streams-provider-gnip/gnip-edc-facebook/pom.xml
@@ -78,7 +78,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source-jaxb2</id>

--- a/streams-contrib/streams-provider-gnip/gnip-edc-youtube/pom.xml
+++ b/streams-contrib/streams-provider-gnip/gnip-edc-youtube/pom.xml
@@ -65,7 +65,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source-jaxb2</id>
@@ -97,7 +96,7 @@
                         <plugin>
                             <groupId>org.jvnet.jaxb2_commons</groupId>
                             <artifactId>jaxb2-basics</artifactId>
-                            <version>0.6.5</version>
+                            <version>${jaxb2-basics.version}</version>
                         </plugin>
                     </plugins>
                 </configuration>

--- a/streams-contrib/streams-provider-gnip/gnip-powertrack/pom.xml
+++ b/streams-contrib/streams-provider-gnip/gnip-powertrack/pom.xml
@@ -74,7 +74,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>
@@ -143,7 +142,7 @@
                         <plugin>
                             <groupId>org.jvnet.jaxb2_commons</groupId>
                             <artifactId>jaxb2-basics</artifactId>
-                            <version>0.6.5</version>
+                            <version>${jaxb2-basics.version}</version>
                         </plugin>
                     </plugins>
                 </configuration>
@@ -157,4 +156,40 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>java8</id>
+            <activation>
+                <jdk>[1.8,]</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <!-- We use this plugin to ensure that our usage of the
+                        maven-jaxb2-plugin is JDK 8 compatible in absence of a fix
+                        for https://java.net/jira/browse/MAVEN_JAXB2_PLUGIN-80. -->
+                        <groupId>org.codehaus.mojo</groupId>
+                        <artifactId>properties-maven-plugin</artifactId>
+                        <version>1.0-alpha-2</version>
+                        <executions>
+                            <execution>
+                                <id>set-additional-system-properties</id>
+                                <goals>
+                                    <goal>set-system-properties</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <properties>
+                                <property>
+                                    <name>javax.xml.accessExternalSchema</name>
+                                    <value>file,http</value>
+                                </property>
+                            </properties>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/streams-contrib/streams-provider-google/google-gmail/pom.xml
+++ b/streams-contrib/streams-provider-google/google-gmail/pom.xml
@@ -91,7 +91,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/streams-contrib/streams-provider-google/google-gplus/pom.xml
+++ b/streams-contrib/streams-provider-google/google-gplus/pom.xml
@@ -98,7 +98,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/streams-contrib/streams-provider-instagram/pom.xml
+++ b/streams-contrib/streams-provider-instagram/pom.xml
@@ -101,7 +101,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/streams-contrib/streams-provider-moreover/pom.xml
+++ b/streams-contrib/streams-provider-moreover/pom.xml
@@ -75,7 +75,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source-jsonschema2pojo</id>
@@ -142,7 +141,7 @@
                         <plugin>
                             <groupId>org.jvnet.jaxb2_commons</groupId>
                             <artifactId>jaxb2-basics</artifactId>
-                            <version>0.6.5</version>
+                            <version>${jaxb2-basics.version}</version>
                         </plugin>
                     </plugins>
                 </configuration>

--- a/streams-contrib/streams-provider-rss/pom.xml
+++ b/streams-contrib/streams-provider-rss/pom.xml
@@ -86,7 +86,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>
@@ -124,45 +123,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <!--<plugin>-->
-                <!--<groupId>org.jvnet.jaxb2.maven2</groupId>-->
-                <!--<artifactId>maven-jaxb2-plugin</artifactId>-->
-                <!--<configuration>-->
-                    <!--<schemaDirectory>src/main/xmlschema</schemaDirectory>-->
-                    <!--<generateDirectory>target/generated-sources/jaxb2</generateDirectory>-->
-                    <!--<verbose>true</verbose>-->
-                    <!--<debug>true</debug>-->
-                    <!--<encoding>${project.build.sourceEncoding}</encoding>-->
-                    <!--<forceRegenerate>true</forceRegenerate>-->
-                    <!--<removeOldOutput>false</removeOldOutput>-->
-                    <!--<generatePackage>org.apache.streams.rss</generatePackage>-->
-                    <!--<schemas>-->
-                        <!--<schema>-->
-                        <!--<fileset>-->
-                            <!--&lt;!&ndash; Defaults to schemaIncludes &ndash;&gt;-->
-                            <!--<includes>-->
-                                <!--<include>contents.xsd</include>-->
-                                <!--<include>opml.xsd</include>-->
-                            <!--</includes>-->
-                        <!--</fileset>-->
-                        <!--</schema>-->
-                    <!--</schemas>-->
-                    <!--&lt;!&ndash;<plugins>&ndash;&gt;-->
-                        <!--&lt;!&ndash;<plugin>&ndash;&gt;-->
-                            <!--&lt;!&ndash;<groupId>org.jvnet.jaxb2_commons</groupId>&ndash;&gt;-->
-                            <!--&lt;!&ndash;<artifactId>jaxb2-basics</artifactId>&ndash;&gt;-->
-                            <!--&lt;!&ndash;<version>0.6.5</version>&ndash;&gt;-->
-                        <!--&lt;!&ndash;</plugin>&ndash;&gt;-->
-                    <!--&lt;!&ndash;</plugins>&ndash;&gt;-->
-                <!--</configuration>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<goals>-->
-                            <!--<goal>generate</goal>-->
-                        <!--</goals>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
         </plugins>
     </build>
 </project>

--- a/streams-contrib/streams-provider-sysomos/pom.xml
+++ b/streams-contrib/streams-provider-sysomos/pom.xml
@@ -84,7 +84,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/streams-contrib/streams-provider-twitter/pom.xml
+++ b/streams-contrib/streams-provider-twitter/pom.xml
@@ -101,7 +101,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>

--- a/streams-pojo/pom.xml
+++ b/streams-pojo/pom.xml
@@ -110,7 +110,6 @@
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>build-helper-maven-plugin</artifactId>
-                <version>1.8</version>
                 <executions>
                     <execution>
                         <id>add-source</id>


### PR DESCRIPTION
... cleanup for good measure.

after this change i could build a stream containing language level 1.8 features with JDK8 on Intel OS X and run with JRE8 for ARM
