### PR TITLE
STREAMS-237 | TwitterActivityUtil now uses the URL that is contained in ...

### DIFF
--- a/streams-contrib/streams-provider-twitter/src/main/java/org/apache/streams/twitter/serializer/util/TwitterActivityUtil.java
+++ b/streams-contrib/streams-provider-twitter/src/main/java/org/apache/streams/twitter/serializer/util/TwitterActivityUtil.java
@@ -225,7 +225,7 @@ public class TwitterActivityUtil {
         List<String> links = Lists.newArrayList();
         if( tweet.getEntities().getUrls() != null ) {
             for (Url url : tweet.getEntities().getUrls()) {
-                links.add(url.getExpandedUrl());
+                links.add(url.getUrl());
             }
         }
         else


### PR DESCRIPTION
...the Tweet's content, instead of the expanded URL in the entity that Twitter gives us
