### PR TITLE
Depricated monitors

### DIFF
--- a/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/builders/LocalStreamBuilder.java
+++ b/streams-runtimes/streams-runtime-local/src/main/java/org/apache/streams/local/builders/LocalStreamBuilder.java
@@ -69,7 +69,7 @@ public class LocalStreamBuilder implements StreamBuilder {
     private int maxQueueCapacity;
     private String streamIdentifier = DEFAULT_STREAM_IDENTIFIER;
     private DateTime startedAt = new DateTime();
-    private boolean useDepricatedMonitors;
+    private boolean useDeprecatedMonitors;
 
     /**
      * Creates a local stream builder with no config object and default maximum internal queue size of 500
@@ -121,14 +121,14 @@ public class LocalStreamBuilder implements StreamBuilder {
         if(this.streamConfig != null) {
             this.streamConfig.put(DEFAULT_STARTED_AT_KEY, startedAt.getMillis());
         }
-        this.useDepricatedMonitors = false;
+        this.useDeprecatedMonitors = false;
         this.broadcastMonitor = new BroadcastMonitorThread(this.streamConfig);
 
         this.futures = new HashMap<>();
     }
 
-    public void setUseDepricatedMonitors(boolean useDepricatedMonitors) {
-        this.useDepricatedMonitors = useDepricatedMonitors;
+    public void setUseDeprecatedMonitors(boolean useDeprecatedMonitors) {
+        this.useDeprecatedMonitors = useDeprecatedMonitors;
     }
 
     @Override
@@ -136,7 +136,7 @@ public class LocalStreamBuilder implements StreamBuilder {
         validateId(id);
         this.providers.put(id, new StreamComponent(id, provider, true, streamConfig));
         ++this.totalTasks;
-        if(this.useDepricatedMonitors && provider instanceof DatumStatusCountable )
+        if(this.useDeprecatedMonitors && provider instanceof DatumStatusCountable )
             ++this.monitorTasks;
         return this;
     }
@@ -146,7 +146,7 @@ public class LocalStreamBuilder implements StreamBuilder {
         validateId(id);
         this.providers.put(id, new StreamComponent(id, provider, false, streamConfig));
         ++this.totalTasks;
-        if(this.useDepricatedMonitors && provider instanceof DatumStatusCountable )
+        if(this.useDeprecatedMonitors && provider instanceof DatumStatusCountable )
             ++this.monitorTasks;
         return this;
     }
@@ -156,7 +156,7 @@ public class LocalStreamBuilder implements StreamBuilder {
         validateId(id);
         this.providers.put(id, new StreamComponent(id, provider, sequence, streamConfig));
         ++this.totalTasks;
-        if(this.useDepricatedMonitors && provider instanceof DatumStatusCountable )
+        if(this.useDeprecatedMonitors && provider instanceof DatumStatusCountable )
             ++this.monitorTasks;
         return this;
     }
@@ -166,7 +166,7 @@ public class LocalStreamBuilder implements StreamBuilder {
         validateId(id);
         this.providers.put(id, new StreamComponent(id, provider, start, end, streamConfig));
         ++this.totalTasks;
-        if(this.useDepricatedMonitors && provider instanceof DatumStatusCountable )
+        if(this.useDeprecatedMonitors && provider instanceof DatumStatusCountable )
             ++this.monitorTasks;
         return this;
     }
@@ -178,7 +178,7 @@ public class LocalStreamBuilder implements StreamBuilder {
         this.components.put(id, comp);
         connectToOtherComponents(inBoundIds, comp);
         this.totalTasks += numTasks;
-        if(this.useDepricatedMonitors && processor instanceof DatumStatusCountable )
+        if(this.useDeprecatedMonitors && processor instanceof DatumStatusCountable )
             ++this.monitorTasks;
         return this;
     }
@@ -190,7 +190,7 @@ public class LocalStreamBuilder implements StreamBuilder {
         this.components.put(id, comp);
         connectToOtherComponents(inBoundIds, comp);
         this.totalTasks += numTasks;
-        if(this.useDepricatedMonitors && writer instanceof DatumStatusCountable )
+        if(this.useDeprecatedMonitors && writer instanceof DatumStatusCountable )
             ++this.monitorTasks;
         return this;
     }
@@ -301,7 +301,7 @@ public class LocalStreamBuilder implements StreamBuilder {
             task.setStreamsTaskCounter(counter);
             this.executor.submit(task);
             provTasks.put(prov.getId(), (StreamsProviderTask) task);
-            if(this.useDepricatedMonitors && prov.isOperationCountable() ) {
+            if(this.useDeprecatedMonitors && prov.isOperationCountable() ) {
                 this.monitor.submit(new StatusCounterMonitorThread((DatumStatusCountable) prov.getOperation(), 10));
                 this.monitor.submit(new StatusCounterMonitorThread((DatumStatusCountable) task, 10));
             }
@@ -319,7 +319,7 @@ public class LocalStreamBuilder implements StreamBuilder {
                 task.setStreamConfig(this.streamConfig);
                 this.futures.put(task, this.executor.submit(task));
                 compTasks.add(task);
-                if(this.useDepricatedMonitors &&  comp.isOperationCountable() ) {
+                if(this.useDeprecatedMonitors &&  comp.isOperationCountable() ) {
                     this.monitor.submit(broadcastMonitor);
                     this.monitor.submit(new StatusCounterMonitorThread((DatumStatusCountable) comp.getOperation(), 10));
                     this.monitor.submit(new StatusCounterMonitorThread((DatumStatusCountable) task, 10));


### PR DESCRIPTION
Disabled the use of the deprecated monitoring threads in local stream builder.  You can still optionally turn them back on through a setter method in the local stream builder.  However, this is not recommended.  If a streams task shutdowns unexpectedly, the monitoring thread will often keep running and keep the stream from terminating appropriately. 
