### PR TITLE
STREAMS-538: switch to git for website publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -298,7 +298,7 @@
         </snapshotRepository>
         <site>
             <id>site.streams.project</id>
-            <url>scm:git:https://github.com/apache/streams.git</url>
+            <url>scm:git:git@github.com:apache/streams.git</url>
         </site>
     </distributionManagement>
 


### PR DESCRIPTION
Have confirmed that with git credentials scm-publish:publish-scm works as desired after this change.