### PR TITLE
STREAMS-557

### DIFF
--- a/streams-contrib/streams-persist-riak/src/main/java/org/apache/streams/riak/http/RiakHttpClient.java
+++ b/streams-contrib/streams-persist-riak/src/main/java/org/apache/streams/riak/http/RiakHttpClient.java
@@ -102,4 +102,7 @@ public class RiakHttpClient {
     return client;
   }
 
+  public URI getBaseURI() {
+    return baseURI;
+  }
 }


### PR DESCRIPTION
STREAMS-557: RiakHttpClient would be more useful if it exposed baseUrl publically (https://issues.apache.org/jira/browse/STREAMS-557)