### PR TITLE
STREAMS-565

### DIFF
--- a/streams-config/src/main/java/org/apache/streams/config/StreamsConfigurator.java
+++ b/streams-config/src/main/java/org/apache/streams/config/StreamsConfigurator.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
+import com.typesafe.config.ConfigResolveOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,6 +48,10 @@ public class StreamsConfigurator {
 
   public static Config getConfig() {
     return config.resolve();
+  }
+
+  public static Config rawConfig() {
+    return config;
   }
 
   public static void addConfig(Config newConfig) {


### PR DESCRIPTION
STREAMS-565: Permit access to StreamsConfigurator underlying Config without resolve() (https://issues.apache.org/jira/browse/STREAMS-565)