### PR TITLE
scala 2.11 and flink 1.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,15 +304,17 @@
 
     <properties>
 
-        <!-- Build Properties -->
+        <!-- Language Library Version Properties -->
         <java.version>1.8</java.version>
         <maven.version>3.3.9</maven.version>
-        <scala.suffix>2.10</scala.suffix>
-        <scala.version>2.10.6</scala.version>
+        <scala.suffix>2.11</scala.suffix>
+        <scala.version>2.11.11</scala.version>
+
+        <!-- Build Properties -->
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <streams.version>0.5.1-SNAPSHOT</streams.version>
+        <streams.version>0.5.2-SNAPSHOT</streams.version>
         <github.global.server>github</github.global.server>
 
         <!-- Release Properties -->
@@ -342,7 +344,7 @@
         <remote-resources.plugin.version>1.4</remote-resources.plugin.version>
         <reports.plugin.version>2.9</reports.plugin.version>
         <resources.plugin.version>2.7</resources.plugin.version>
-        <scala.plugin.version>3.2.2</scala.plugin.version>
+        <scala.plugin.version>3.3.2</scala.plugin.version>
         <scalastyle.plugin.version>0.8.0</scalastyle.plugin.version>
         <scm.plugin.version>1.9.5</scm.plugin.version>
         <scmpublish.plugin.version>1.1</scmpublish.plugin.version>
@@ -354,12 +356,12 @@
         <war.plugin.version>2.5</war.plugin.version>
 
         <!-- Library Dependency Versions -->
-        <jackson.version>2.6.5</jackson.version>
+        <jackson.version>2.7.9</jackson.version>
         <jackson-xml-databind.version>0.6.2</jackson-xml-databind.version>
         <aalto.version>1.0.0</aalto.version>
         <joda-time.version>2.9.9</joda-time.version>
         <joda-convert.version>1.8.1</joda-convert.version>
-        <json-flattener.version>0.4.1</json-flattener.version>
+        <json-flattener.version>0.5.0</json-flattener.version>
         <json-schema-validator.version>0.1.10</json-schema-validator.version>
         <juneau.version>7.0.1</juneau.version>
         <jsonschema2pojo.version>0.4.10</jsonschema2pojo.version>

--- a/streams-examples/streams-examples-flink/flink-twitter-collection/pom.xml
+++ b/streams-examples/streams-examples-flink/flink-twitter-collection/pom.xml
@@ -26,19 +26,20 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>streams-flink-twitter-collection</artifactId>
-    <name>flink-twitter-collection</name>
+    <artifactId>streams-example-flink-twitter-collection</artifactId>
+    <name>streams-example-flink-twitter-collection</name>
 
     <description>Collects twitter documents using flink.</description>
 
     <properties>
         <testng.version>6.9.10</testng.version>
         <hdfs.version>2.7.0</hdfs.version>
-        <flink.version>1.2.0</flink.version>
-        <scala.version>2.10.6</scala.version>
-        <scalatest.version>2.2.5</scalatest.version>
-        <scala.suffix>2.10</scala.suffix>
-        <scala-maven.plugin.version>3.2.2</scala-maven.plugin.version>
+        <flink.version>1.4.2</flink.version>
+        <scala.suffix>2.11</scala.suffix>
+        <scala.version>2.11.12</scala.version>
+        <scalapc.version>1.1.0</scalapc.version>
+        <scalatest.version>3.0.0</scalatest.version>
+        <scalaxml.version>1.1.0</scalaxml.version>
     </properties>
 
     <dependencies>
@@ -196,7 +197,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-filesystem_2.10</artifactId>
+            <artifactId>flink-connector-filesystem_${scala.suffix}</artifactId>
             <version>${flink.version}</version>
             <exclusions>
                 <exclusion>
@@ -362,7 +363,6 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>${scala-maven.plugin.version}</version>
                 <executions>
                     <execution>
                         <id>scala-compile-first</id>
@@ -463,5 +463,20 @@
             </plugin>
         </plugins>
     </build>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.scala-lang.modules</groupId>
+                <artifactId>scala-xml_${scala.suffix}</artifactId>
+                <version>${scalaxml.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.scala-lang.modules</groupId>
+                <artifactId>scala-parser-combinators_2.11</artifactId>
+                <version>${scalapc.version}</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
 </project>


### PR DESCRIPTION
switch to scala 2.11, required by latest releases of flink / kafka / spark
upgrade to latest release of flink
other related version bumps and explicitization
resolves STREAMS-573
resolves STREAMS-585