### PR TITLE
STREAMS-487: zip resource artifacts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -864,6 +864,34 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
                     <version>${dependency.plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <id>unpack-schemas</id>
+                            <phase>generate-sources</phase>
+                            <goals>
+                                <goal>unpack-dependencies</goal>
+                            </goals>
+                            <configuration>
+                                <excludeTransitive>true</excludeTransitive>
+                                <includeGroupIds>org.apache.streams</includeGroupIds>
+                                <includeScope>compile</includeScope>
+                                <includeTypes>zip</includeTypes>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>unpack-test-resources</id>
+                            <phase>process-test-resources</phase>
+                            <goals>
+                                <goal>unpack-dependencies</goal>
+                            </goals>
+                            <configuration>
+                                <excludeTransitive>true</excludeTransitive>
+                                <includeGroupIds>org.apache.streams</includeGroupIds>
+                                <includeScope>test</includeScope>
+                                <includeTypes>zip</includeTypes>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -879,60 +907,6 @@
                     <groupId>io.fabric8</groupId>
                     <artifactId>docker-maven-plugin</artifactId>
                     <version>${docker.plugin.version}</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-checkstyle-plugin</artifactId>
-                    <version>${checkstyle.plugin.version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>com.puppycrawl.tools</groupId>
-                            <artifactId>checkstyle</artifactId>
-                            <version>7.2</version>
-                        </dependency>
-                    </dependencies>
-                    <executions>
-                        <execution>
-                            <id>validate</id>
-                            <phase>validate</phase>
-                            <configuration>
-                                <configLocation>src/main/resources/streams-java-checkstyle.xml</configLocation>
-                                <encoding>UTF-8</encoding>
-                                <consoleOutput>true</consoleOutput>
-                                <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                                <testSourceDirectory>${project.basedir}/src/test/java</testSourceDirectory>
-                                <failsOnError>false</failsOnError>
-                            </configuration>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
-                <plugin>
-                    <groupId>org.scalastyle</groupId>
-                    <artifactId>scalastyle-maven-plugin</artifactId>
-                    <version>${scalastyle.plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <id>validate</id>
-                            <phase>validate</phase>
-                            <configuration>
-                                <verbose>false</verbose>
-                                <failOnViolation>false</failOnViolation>
-                                <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                                <failOnWarning>false</failOnWarning>
-                                <sourceDirectory>${project.basedir}/src/main/scala</sourceDirectory>
-                                <testSourceDirectory>${project.basedir}/src/test/scala</testSourceDirectory>
-                                <!--<configLocation>https://raw.githubusercontent.com/databricks/sbt-databricks/master/scalastyle-config.xml</configLocation>-->
-                                <outputFile>${project.build.directory}/scalastyle-output.xml</outputFile>
-                                <outputEncoding>UTF-8</outputEncoding>
-                            </configuration>
-                            <goals>
-                                <goal>check</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>net.alchim31.maven</groupId>

--- a/streams-contrib/streams-persist-cassandra/pom.xml
+++ b/streams-contrib/streams-persist-cassandra/pom.xml
@@ -127,20 +127,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includes>**/*.json</includes>
-                            <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/streams-contrib/streams-persist-elasticsearch/pom.xml
+++ b/streams-contrib/streams-persist-elasticsearch/pom.xml
@@ -168,22 +168,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <includes>**/*.json</includes>
-                    <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                    <includeGroupIds>org.apache.streams</includeGroupIds>
-                    <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                    <includeTypes>test-jar</includeTypes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>test-resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/streams-contrib/streams-persist-hdfs/pom.xml
+++ b/streams-contrib/streams-persist-hdfs/pom.xml
@@ -193,20 +193,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includes>**/*.json</includes>
-                            <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/streams-contrib/streams-persist-mongo/pom.xml
+++ b/streams-contrib/streams-persist-mongo/pom.xml
@@ -115,20 +115,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includes>**/*.json</includes>
-                            <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/streams-contrib/streams-persist-neo4j/pom.xml
+++ b/streams-contrib/streams-persist-neo4j/pom.xml
@@ -171,23 +171,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <includes>**/*.json</includes>
-                    <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                    <includeGroupIds>org.apache.streams</includeGroupIds>
-                    <includeTypes>test-jar</includeTypes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>test-resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
-
         </plugins>
     </build>
 

--- a/streams-contrib/streams-persist-riak/pom.xml
+++ b/streams-contrib/streams-persist-riak/pom.xml
@@ -216,21 +216,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-dependency-plugin</artifactId>
-                        <configuration>
-                            <includes>**/*.json</includes>
-                            <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeTypes>test-jar</includeTypes>
-                        </configuration>
-                        <executions>
-                            <execution>
-                                <id>test-resource-dependencies</id>
-                                <phase>process-test-resources</phase>
-                                <goals>
-                                    <goal>unpack-dependencies</goal>
-                                </goals>
-                            </execution>
-                        </executions>
                     </plugin>
 
                 </plugins>

--- a/streams-examples/streams-examples-local/elasticsearch-hdfs/pom.xml
+++ b/streams-examples/streams-examples-local/elasticsearch-hdfs/pom.xml
@@ -285,22 +285,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <includes>**/*.json</includes>
-                    <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                    <includeGroupIds>org.apache.streams</includeGroupIds>
-                    <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                    <includeTypes>test-jar</includeTypes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>test-resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/streams-examples/streams-examples-local/elasticsearch-reindex/pom.xml
+++ b/streams-examples/streams-examples-local/elasticsearch-reindex/pom.xml
@@ -249,22 +249,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <includes>**/*.json</includes>
-                    <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                    <includeGroupIds>org.apache.streams</includeGroupIds>
-                    <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                    <includeTypes>test-jar</includeTypes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>test-resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/streams-examples/streams-examples-local/mongo-elasticsearch-sync/pom.xml
+++ b/streams-examples/streams-examples-local/mongo-elasticsearch-sync/pom.xml
@@ -253,22 +253,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <includes>**/*.json</includes>
-                    <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                    <includeGroupIds>org.apache.streams</includeGroupIds>
-                    <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                    <includeTypes>test-jar</includeTypes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>test-resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/streams-examples/streams-examples-local/twitter-follow-neo4j/pom.xml
+++ b/streams-examples/streams-examples-local/twitter-follow-neo4j/pom.xml
@@ -233,21 +233,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.4</version>
-                <executions>
-                    <execution>
-                        <id>resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeArtifactIds>streams-schemas-activitystreams</includeArtifactIds>
-                            <includes>**/*.json</includes>
-                            <outputDirectory>${project.build.directory}/test-classes</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/streams-plugins/streams-plugin-cassandra/pom.xml
+++ b/streams-plugins/streams-plugin-cassandra/pom.xml
@@ -38,6 +38,22 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>schemas</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>testdata</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
             <artifactId>streams-config</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -172,22 +188,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includes>**/*.json</includes>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includeTypes>jar</includeTypes>
-                            <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
         </plugins>

--- a/streams-plugins/streams-plugin-cassandra/src/test/java/org/apache/streams/plugins/cassandra/test/StreamsCassandraResourceGeneratorCLITest.java
+++ b/streams-plugins/streams-plugin-cassandra/src/test/java/org/apache/streams/plugins/cassandra/test/StreamsCassandraResourceGeneratorCLITest.java
@@ -39,7 +39,7 @@ public class StreamsCassandraResourceGeneratorCLITest {
   @Test
   public void testStreamsCassandraResourceGeneratorCLI() throws Exception {
 
-    String sourceDirectory = "target/test-classes/activitystreams-schemas";
+    String sourceDirectory = "target/dependency/activitystreams-schemas";
     String targetDirectory = "target/generated-resources/test-cli";
 
     StreamsCassandraResourceGenerator.main(new String[]{sourceDirectory, targetDirectory});

--- a/streams-plugins/streams-plugin-cassandra/src/test/java/org/apache/streams/plugins/cassandra/test/StreamsCassandraResourceGeneratorTest.java
+++ b/streams-plugins/streams-plugin-cassandra/src/test/java/org/apache/streams/plugins/cassandra/test/StreamsCassandraResourceGeneratorTest.java
@@ -55,7 +55,7 @@ public class StreamsCassandraResourceGeneratorTest {
 
     StreamsCassandraGenerationConfig config = new StreamsCassandraGenerationConfig();
 
-    String sourceDirectory = "target/test-classes/activitystreams-schemas";
+    String sourceDirectory = "target/dependency/activitystreams-schemas";
 
     config.setSourceDirectory(sourceDirectory);
 

--- a/streams-plugins/streams-plugin-cassandra/src/test/resources/streams-plugin-cassandra/pom.xml
+++ b/streams-plugins/streams-plugin-cassandra/src/test/resources/streams-plugin-cassandra/pom.xml
@@ -101,12 +101,12 @@
                 <version>0.5.1-SNAPSHOT</version>
                 <configuration>
                     <sourcePaths>
-                        <sourcePath>target/test-classes/activitystreams-schemas/activity.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/collection.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/media_link.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/object.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/objectTypes</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/verbs</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/activity.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/collection.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/media_link.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/object.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/objectTypes</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/verbs</sourcePath>
                     </sourcePaths>
                     <targetDirectory>target/generated-resources/test-mojo</targetDirectory>
                 </configuration>
@@ -121,22 +121,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <includes>**/*.json</includes>
-                    <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                    <includeGroupIds>org.apache.streams</includeGroupIds>
-                    <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                    <includeTypes>jar</includeTypes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>unpack-schemas</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/streams-plugins/streams-plugin-elasticsearch/pom.xml
+++ b/streams-plugins/streams-plugin-elasticsearch/pom.xml
@@ -39,6 +39,22 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>schemas</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>testdata</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
             <artifactId>streams-config</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -173,22 +189,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includes>**/*.json</includes>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includeTypes>jar</includeTypes>
-                            <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
         </plugins>

--- a/streams-plugins/streams-plugin-elasticsearch/src/test/java/org/apache/streams/plugins/elasticsearch/test/StreamsElasticsearchResourceGeneratorCLITest.java
+++ b/streams-plugins/streams-plugin-elasticsearch/src/test/java/org/apache/streams/plugins/elasticsearch/test/StreamsElasticsearchResourceGeneratorCLITest.java
@@ -36,7 +36,7 @@ public class StreamsElasticsearchResourceGeneratorCLITest {
   @Test
   public void testStreamsElasticsearchResourceGeneratorCLI() throws Exception {
 
-    String sourceDirectory = "target/test-classes/activitystreams-schemas";
+    String sourceDirectory = "target/dependency/activitystreams-schemas";
     String targetDirectory = "target/generated-resources/elasticsearch-cli";
 
     StreamsElasticsearchResourceGenerator.main(new String[]{sourceDirectory, targetDirectory});

--- a/streams-plugins/streams-plugin-elasticsearch/src/test/java/org/apache/streams/plugins/elasticsearch/test/StreamsElasticsearchResourceGeneratorTest.java
+++ b/streams-plugins/streams-plugin-elasticsearch/src/test/java/org/apache/streams/plugins/elasticsearch/test/StreamsElasticsearchResourceGeneratorTest.java
@@ -52,7 +52,7 @@ public class StreamsElasticsearchResourceGeneratorTest {
 
     StreamsElasticsearchGenerationConfig config = new StreamsElasticsearchGenerationConfig();
 
-    String sourceDirectory = "target/test-classes/activitystreams-schemas";
+    String sourceDirectory = "target/dependency/activitystreams-schemas";
 
     config.setSourceDirectory(sourceDirectory);
 

--- a/streams-plugins/streams-plugin-elasticsearch/src/test/resources/streams-plugin-elasticsearch/pom.xml
+++ b/streams-plugins/streams-plugin-elasticsearch/src/test/resources/streams-plugin-elasticsearch/pom.xml
@@ -101,12 +101,12 @@
                 <version>0.5.1-SNAPSHOT</version>
                 <configuration>
                     <sourcePaths>
-                        <sourcePath>target/test-classes/activitystreams-schemas/activity.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/collection.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/media_link.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/object.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/objectTypes</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/verbs</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/activity.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/collection.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/media_link.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/object.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/objectTypes</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/verbs</sourcePath>
                     </sourcePaths>
                     <targetDirectory>target/generated-resources/elasticsearch-mojo</targetDirectory>
                 </configuration>
@@ -121,22 +121,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <includes>**/*.json</includes>
-                    <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                    <includeGroupIds>org.apache.streams</includeGroupIds>
-                    <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                    <includeTypes>jar</includeTypes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>unpack-schemas</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/streams-plugins/streams-plugin-hbase/pom.xml
+++ b/streams-plugins/streams-plugin-hbase/pom.xml
@@ -38,6 +38,22 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>schemas</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>testdata</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
             <artifactId>streams-config</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -172,22 +188,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includes>**/*.json</includes>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includeTypes>jar</includeTypes>
-                            <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
         </plugins>

--- a/streams-plugins/streams-plugin-hbase/src/test/java/org/apache/streams/plugins/test/StreamsHbaseResourceGeneratorCLITest.java
+++ b/streams-plugins/streams-plugin-hbase/src/test/java/org/apache/streams/plugins/test/StreamsHbaseResourceGeneratorCLITest.java
@@ -36,7 +36,7 @@ public class StreamsHbaseResourceGeneratorCLITest {
   @Test
   public void testStreamsHbaseResourceGeneratorCLI() throws Exception {
 
-    String sourceDirectory = "target/test-classes/activitystreams-schemas";
+    String sourceDirectory = "target/dependency/activitystreams-schemas";
     String targetDirectory = "target/generated-resources/hbase-cli";
 
     StreamsHbaseResourceGenerator.main(new String[]{sourceDirectory, targetDirectory});

--- a/streams-plugins/streams-plugin-hbase/src/test/java/org/apache/streams/plugins/test/StreamsHbaseResourceGeneratorTest.java
+++ b/streams-plugins/streams-plugin-hbase/src/test/java/org/apache/streams/plugins/test/StreamsHbaseResourceGeneratorTest.java
@@ -52,7 +52,7 @@ public class StreamsHbaseResourceGeneratorTest {
 
     StreamsHbaseGenerationConfig config = new StreamsHbaseGenerationConfig();
 
-    String sourceDirectory = "target/test-classes/activitystreams-schemas";
+    String sourceDirectory = "target/dependency/activitystreams-schemas";
 
     config.setSourceDirectory(sourceDirectory);
 

--- a/streams-plugins/streams-plugin-hbase/src/test/resources/streams-plugin-hbase/pom.xml
+++ b/streams-plugins/streams-plugin-hbase/src/test/resources/streams-plugin-hbase/pom.xml
@@ -102,12 +102,12 @@
                 <version>0.5.1-SNAPSHOT</version>
                 <configuration>
                     <sourcePaths>
-                        <sourcePath>target/test-classes/activitystreams-schemas/activity.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/collection.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/media_link.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/object.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/objectTypes</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/verbs</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/activity.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/collection.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/media_link.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/object.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/objectTypes</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/verbs</sourcePath>
                     </sourcePaths>
                     <targetDirectory>target/generated-resources/hbase-mojo</targetDirectory>
                     <columnFamily>cf</columnFamily>
@@ -123,22 +123,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <includes>**/*.json</includes>
-                    <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                    <includeGroupIds>org.apache.streams</includeGroupIds>
-                    <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                    <includeTypes>jar</includeTypes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>unpack-schemas</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/streams-plugins/streams-plugin-hive/pom.xml
+++ b/streams-plugins/streams-plugin-hive/pom.xml
@@ -38,6 +38,22 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>schemas</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>testdata</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
             <artifactId>streams-config</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -172,22 +188,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includes>**/*.json</includes>
-                            <includeTypes>jar</includeTypes>
-                            <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
         </plugins>

--- a/streams-plugins/streams-plugin-hive/src/test/java/org/apache/streams/plugins/test/StreamsHiveResourceGeneratorCLITest.java
+++ b/streams-plugins/streams-plugin-hive/src/test/java/org/apache/streams/plugins/test/StreamsHiveResourceGeneratorCLITest.java
@@ -36,7 +36,7 @@ public class StreamsHiveResourceGeneratorCLITest {
   @Test
   public void testStreamsHiveResourceGeneratorCLI() throws Exception {
 
-    String sourceDirectory = "target/test-classes/activitystreams-schemas";
+    String sourceDirectory = "target/dependency/activitystreams-schemas";
     String targetDirectory = "target/generated-resources/hive-cli";
 
     StreamsHiveResourceGenerator.main(new String[]{sourceDirectory, targetDirectory});

--- a/streams-plugins/streams-plugin-hive/src/test/java/org/apache/streams/plugins/test/StreamsHiveResourceGeneratorTest.java
+++ b/streams-plugins/streams-plugin-hive/src/test/java/org/apache/streams/plugins/test/StreamsHiveResourceGeneratorTest.java
@@ -54,7 +54,7 @@ public class StreamsHiveResourceGeneratorTest {
 
     StreamsHiveGenerationConfig config = new StreamsHiveGenerationConfig();
 
-    String sourceDirectory = "target/test-classes/activitystreams-schemas";
+    String sourceDirectory = "target/dependency/activitystreams-schemas";
 
     config.setSourceDirectory(sourceDirectory);
 

--- a/streams-plugins/streams-plugin-hive/src/test/resources/streams-plugin-hive/pom.xml
+++ b/streams-plugins/streams-plugin-hive/src/test/resources/streams-plugin-hive/pom.xml
@@ -102,12 +102,12 @@
                 <version>0.5.1-SNAPSHOT</version>
                 <configuration>
                     <sourcePaths>
-                        <sourcePath>target/test-classes/activitystreams-schemas/activity.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/collection.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/media_link.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/object.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/objectTypes</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/verbs</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/activity.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/collection.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/media_link.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/object.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/objectTypes</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/verbs</sourcePath>
                     </sourcePaths>
                     <targetDirectory>target/generated-resources/hive-mojo</targetDirectory>
                 </configuration>
@@ -122,22 +122,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <includes>**/*.json</includes>
-                    <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                    <includeGroupIds>org.apache.streams</includeGroupIds>
-                    <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                    <includeTypes>jar</includeTypes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>unpack-schemas</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/streams-plugins/streams-plugin-pig/pom.xml
+++ b/streams-plugins/streams-plugin-pig/pom.xml
@@ -38,6 +38,22 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>schemas</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>testdata</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
             <artifactId>streams-config</artifactId>
             <version>${project.version}</version>
             <exclusions>
@@ -172,22 +188,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includes>**/*.json</includes>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includeTypes>jar</includeTypes>
-                            <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
         </plugins>

--- a/streams-plugins/streams-plugin-pig/src/test/java/org/apache/streams/plugins/pig/test/StreamsPigResourceGeneratorCLITest.java
+++ b/streams-plugins/streams-plugin-pig/src/test/java/org/apache/streams/plugins/pig/test/StreamsPigResourceGeneratorCLITest.java
@@ -36,7 +36,7 @@ public class StreamsPigResourceGeneratorCLITest {
   @Test
   public void testStreamsPigResourceGeneratorCLI() throws Exception {
 
-    String sourceDirectory = "target/test-classes/activitystreams-schemas";
+    String sourceDirectory = "target/dependency/activitystreams-schemas";
     String targetDirectory = "target/generated-resources/pig-cli";
 
     StreamsPigResourceGenerator.main(new String[]{sourceDirectory, targetDirectory});

--- a/streams-plugins/streams-plugin-pig/src/test/java/org/apache/streams/plugins/pig/test/StreamsPigResourceGeneratorTest.java
+++ b/streams-plugins/streams-plugin-pig/src/test/java/org/apache/streams/plugins/pig/test/StreamsPigResourceGeneratorTest.java
@@ -52,7 +52,7 @@ public class StreamsPigResourceGeneratorTest {
 
     StreamsPigGenerationConfig config = new StreamsPigGenerationConfig();
 
-    String sourceDirectory = "target/test-classes/activitystreams-schemas";
+    String sourceDirectory = "target/dependency/activitystreams-schemas";
 
     config.setSourceDirectory(sourceDirectory);
 

--- a/streams-plugins/streams-plugin-pig/src/test/resources/streams-plugin-pig/pom.xml
+++ b/streams-plugins/streams-plugin-pig/src/test/resources/streams-plugin-pig/pom.xml
@@ -102,12 +102,12 @@
                 <version>0.5.1-SNAPSHOT</version>
                 <configuration>
                     <sourcePaths>
-                        <sourcePath>target/test-classes/activitystreams-schemas/activity.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/collection.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/media_link.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/object.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/objectTypes</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/verbs</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/activity.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/collection.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/media_link.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/object.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/objectTypes</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/verbs</sourcePath>
                     </sourcePaths>
                     <targetDirectory>target/generated-resources/pig-mojo</targetDirectory>
                 </configuration>
@@ -122,22 +122,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <includes>**/*.json</includes>
-                    <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                    <includeGroupIds>org.apache.streams</includeGroupIds>
-                    <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                    <includeTypes>jar</includeTypes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>unpack-schemas</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/streams-plugins/streams-plugin-pojo/pom.xml
+++ b/streams-plugins/streams-plugin-pojo/pom.xml
@@ -36,7 +36,16 @@
             <groupId>org.apache.streams</groupId>
             <artifactId>streams-schema-activitystreams</artifactId>
             <version>${project.version}</version>
-            <type>jar</type>
+            <type>zip</type>
+            <classifier>schemas</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>testdata</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -167,36 +176,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>activitystreams-schemas</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includes>**/*.json</includes>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includeTypes>jar</includeTypes>
-                            <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>activitystreams-testdocs</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includes>**/*.json</includes>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includeTypes>test-jar</includeTypes>
-                            <outputDirectory>${project.build.directory}/test-classes/activitystreams-testdocs</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
 
         </plugins>

--- a/streams-plugins/streams-plugin-pojo/src/test/java/org/apache/streams/plugins/test/StreamsPojoSourceGeneratorCLITest.java
+++ b/streams-plugins/streams-plugin-pojo/src/test/java/org/apache/streams/plugins/test/StreamsPojoSourceGeneratorCLITest.java
@@ -40,7 +40,7 @@ public class StreamsPojoSourceGeneratorCLITest {
   @Test
   public void testStreamsPojoSourceGeneratorCLI() throws Exception {
 
-    String sourceDirectory = "target/test-classes/activitystreams-schemas";
+    String sourceDirectory = "target/dependency/activitystreams-schemas";
     String targetDirectory = "target/generated-sources/test-cli";
 
     StreamsPojoSourceGenerator.main(new String[]{sourceDirectory, targetDirectory});

--- a/streams-plugins/streams-plugin-pojo/src/test/java/org/apache/streams/plugins/test/StreamsPojoSourceGeneratorTest.java
+++ b/streams-plugins/streams-plugin-pojo/src/test/java/org/apache/streams/plugins/test/StreamsPojoSourceGeneratorTest.java
@@ -55,12 +55,12 @@ public class StreamsPojoSourceGeneratorTest {
     StreamsPojoGenerationConfig config = new StreamsPojoGenerationConfig();
 
     List<String> sourcePaths = Stream.of(
-        "target/test-classes/activitystreams-schemas/activity.json",
-        "target/test-classes/activitystreams-schemas/collection.json",
-        "target/test-classes/activitystreams-schemas/media_link.json",
-        "target/test-classes/activitystreams-schemas/object.json",
-        "target/test-classes/activitystreams-schemas/objectTypes",
-        "target/test-classes/activitystreams-schemas/verbs"
+        "target/dependency/activitystreams-schemas/activity.json",
+        "target/dependency/activitystreams-schemas/collection.json",
+        "target/dependency/activitystreams-schemas/media_link.json",
+        "target/dependency/activitystreams-schemas/object.json",
+        "target/dependency/activitystreams-schemas/objectTypes",
+        "target/dependency/activitystreams-schemas/verbs"
     ).collect(Collectors.toList());
     config.setSourcePaths(sourcePaths);
 

--- a/streams-plugins/streams-plugin-pojo/src/test/resources/streams-plugin-pojo/pom.xml
+++ b/streams-plugins/streams-plugin-pojo/src/test/resources/streams-plugin-pojo/pom.xml
@@ -143,12 +143,12 @@
                 <version>${project.version}</version>
                 <configuration>
                     <sourcePaths>
-                        <sourcePath>target/test-classes/activitystreams-schemas/activity.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/collection.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/media_link.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/object.json</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/objectTypes</sourcePath>
-                        <sourcePath>target/test-classes/activitystreams-schemas/verbs</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/activity.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/collection.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/media_link.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/object.json</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/objectTypes</sourcePath>
+                        <sourcePath>target/dependency/activitystreams-schemas/verbs</sourcePath>
                     </sourcePaths>
                     <targetPackage>org.apache.streams.pojo.mojo</targetPackage>
                     <targetDirectory>target/generated-sources/pojo-mojo</targetDirectory>
@@ -164,22 +164,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <configuration>
-                    <includes>**/*.json</includes>
-                    <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                    <includeGroupIds>org.apache.streams</includeGroupIds>
-                    <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                    <includeTypes>jar</includeTypes>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>unpack-schemas</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/streams-plugins/streams-plugin-scala/pom.xml
+++ b/streams-plugins/streams-plugin-scala/pom.xml
@@ -33,6 +33,22 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>schemas</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>testdata</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
             <artifactId>streams-config</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -168,35 +184,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>streams-pojo-resource-dependencies</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeArtifactIds>streams-pojo</includeArtifactIds>
-                            <includes>org/apache/streams/pojo/json/**</includes>
-                            <outputDirectory>${project.build.directory}/test-classes/streams-pojo</outputDirectory>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>activitystreams-testdocs</id>
-                        <phase>process-test-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includes>**/*.json</includes>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includeTypes>test-jar</includeTypes>
-                            <outputDirectory>${project.build.directory}/test-classes/activitystreams-testdocs</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>net.alchim31.maven</groupId>

--- a/streams-pojo/pom.xml
+++ b/streams-pojo/pom.xml
@@ -33,7 +33,22 @@
     <description>Activity json schemas and POJOs, and supporting classes.</description>
 
     <dependencies>
-
+        <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>schemas</classifier>
+            <scope>compile</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>testdata</classifier>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.juneau</groupId>
             <artifactId>juneau-marshall</artifactId>
@@ -174,36 +189,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack-schemas</id>
-                        <phase>generate-sources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includes>**/*.json</includes>
-                            <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includeTypes>jar</includeTypes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>unpack-testdocs</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includes>**/*.json</includes>
-                            <outputDirectory>${project.build.directory}/test-classes/activitystreams-testdocs</outputDirectory>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includeTypes>test-jar</includeTypes>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
             <plugin>
                 <groupId>org.apache.streams.plugins</groupId>
@@ -212,9 +197,9 @@
                 <configuration>
                     <sourcePaths>
                         <sourcePath>${project.basedir}/src/main/jsonschema</sourcePath>
-                        <sourcePath>${project.basedir}/target/test-classes/activitystreams-schemas</sourcePath>
-                        <sourcePath>${project.basedir}/target/test-classes/activitystreams-schemas/objectTypes</sourcePath>
-                        <sourcePath>${project.basedir}/target/test-classes/activitystreams-schemas/verbs</sourcePath>
+                        <sourcePath>${project.basedir}/target/dependency/activitystreams-schemas</sourcePath>
+                        <sourcePath>${project.basedir}/target/dependency/activitystreams-schemas/objectTypes</sourcePath>
+                        <sourcePath>${project.basedir}/target/dependency/activitystreams-schemas/verbs</sourcePath>
                     </sourcePaths>
                     <targetDirectory>${project.basedir}/target/generated-sources/pojo</targetDirectory>
                     <targetPackage>org.apache.streams.pojo.json</targetPackage>

--- a/streams-pojo/src/test/java/org/apache/streams/pojo/test/ActivitySerDeTest.java
+++ b/streams-pojo/src/test/java/org/apache/streams/pojo/test/ActivitySerDeTest.java
@@ -31,11 +31,17 @@ import org.reflections.util.ConfigurationBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.FileInputStream;
 import java.io.InputStream;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Test that Activity beans are compatible with the example activities in the spec.
@@ -53,15 +59,12 @@ public class ActivitySerDeTest {
   @Test
   public void testActivitySerDe() throws Exception {
 
-    InputStream testActivityFolderStream = ActivitySerDeTest.class.getClassLoader()
-        .getResourceAsStream("activitystreams-testdocs/activities");
-    List<String> files = IOUtils.readLines(testActivityFolderStream, StandardCharsets.UTF_8);
-
-    for ( String file : files) {
-      LOGGER.info("File: " + file );
-      LOGGER.info("Serializing: activities/" + file );
-      InputStream testActivityFileStream = ActivitySerDeTest.class.getClassLoader()
-          .getResourceAsStream("activities/" + file);
+    Path testdataDir = Paths.get("target/dependency/activitystreams-testdata");
+    List<Path> schemaPaths = Files.list(testdataDir).collect(Collectors.toList());
+    for( Path schemaPath : schemaPaths ) {
+      LOGGER.info("Path: " + schemaPath );
+      LOGGER.info("Serializing: activities/" + schemaPath );
+      FileInputStream testActivityFileStream = new FileInputStream(schemaPath.toFile());
       Activity activity = MAPPER.readValue(testActivityFileStream, Activity.class);
       activity.setGenerator(null);
       activity.setLinks(new LinkedList<>());
@@ -91,9 +94,9 @@ public class ActivitySerDeTest {
       String verbName = activity.getVerb();
       String testfile = verbName.toLowerCase() + ".json";
       LOGGER.info("Serializing: activities/" + testfile );
-      assert (ActivitySerDeTest.class.getClassLoader().getResource("activities/" + testfile) != null);
-      InputStream testActivityFileStream = ActivitySerDeTest.class.getClassLoader()
-          .getResourceAsStream("activities/" + testfile);
+      Path testActivityPath = Paths.get("target/dependency/activitystreams-testdata/" + testfile);
+      assert (testActivityPath.toFile().exists());
+      FileInputStream testActivityFileStream = new FileInputStream(testActivityPath.toFile());
       assert (testActivityFileStream != null);
       activity = MAPPER.convertValue(MAPPER.readValue(testActivityFileStream, verbClass), Activity.class);
       String activityString = MAPPER.writeValueAsString(activity);

--- a/streams-schemas/streams-schema-activitystreams/pom.xml
+++ b/streams-schemas/streams-schema-activitystreams/pom.xml
@@ -96,16 +96,40 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
-                <configuration>
-                    <includes>
-                        <include>**/*.json</include>
-                    </includes>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
                             <goal>test-jar</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>schemas</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/resources/assembly-schemas.xml</descriptor>
+                            </descriptors>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>testdata</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/test/resources/assembly-testdata.xml</descriptor>
+                            </descriptors>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/streams-schemas/streams-schema-activitystreams/src/main/resources/assembly-schemas.xml
+++ b/streams-schemas/streams-schema-activitystreams/src/main/resources/assembly-schemas.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>schemas</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>src/main/jsonschema</directory>
+            <outputDirectory>/activitystreams-schemas</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/streams-schemas/streams-schema-activitystreams/src/test/resources/assembly-testdata.xml
+++ b/streams-schemas/streams-schema-activitystreams/src/test/resources/assembly-testdata.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one
+  ~ or more contributor license agreements.  See the NOTICE file
+  ~ distributed with this work for additional information
+  ~ regarding copyright ownership.  The ASF licenses this file
+  ~ to you under the Apache License, Version 2.0 (the
+  ~ "License"); you may not use this file except in compliance
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+    <id>testdata</id>
+    <formats>
+        <format>zip</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>src/test/resources/activities</directory>
+            <outputDirectory>/activitystreams-testdata</outputDirectory>
+        </fileSet>
+    </fileSets>
+</assembly>

--- a/streams-util/pom.xml
+++ b/streams-util/pom.xml
@@ -34,6 +34,22 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>schemas</classifier>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.streams</groupId>
+            <artifactId>streams-schema-activitystreams</artifactId>
+            <version>${project.version}</version>
+            <type>zip</type>
+            <classifier>testdata</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
@@ -79,10 +95,9 @@
         </dependency>
         <dependency>
             <groupId>org.apache.streams</groupId>
-            <artifactId>streams-schema-activitystreams</artifactId>
+            <artifactId>streams-config</artifactId>
             <version>${project.version}</version>
             <scope>test</scope>
-            <type>jar</type>
         </dependency>
         <dependency>
             <groupId>org.apache.streams</groupId>
@@ -143,36 +158,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>unpack-schemas</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includes>**/*.json</includes>
-                            <outputDirectory>${project.build.directory}/test-classes/activitystreams-schemas</outputDirectory>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includeTypes>jar</includeTypes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>unpack-testdocs</id>
-                        <phase>process-resources</phase>
-                        <goals>
-                            <goal>unpack-dependencies</goal>
-                        </goals>
-                        <configuration>
-                            <includes>**/*.json</includes>
-                            <outputDirectory>${project.build.directory}/test-classes/activitystreams-testdocs</outputDirectory>
-                            <includeGroupIds>org.apache.streams</includeGroupIds>
-                            <includeArtifactIds>streams-schema-activitystreams</includeArtifactIds>
-                            <includeTypes>test-jar</includeTypes>
-                        </configuration>
-                    </execution>
-                </executions>
             </plugin>
         </plugins>
     </build>

--- a/streams-util/src/test/java/org/apache/streams/util/schema/test/SchemaOrderingTest.java
+++ b/streams-util/src/test/java/org/apache/streams/util/schema/test/SchemaOrderingTest.java
@@ -18,6 +18,7 @@
 
 package org.apache.streams.util.schema.test;
 
+import org.apache.streams.config.StreamsConfigurator;
 import org.apache.streams.util.schema.Schema;
 import org.apache.streams.util.schema.SchemaStore;
 import org.apache.streams.util.schema.SchemaStoreImpl;
@@ -27,6 +28,8 @@ import com.google.common.base.Predicate;
 import com.google.common.collect.Iterators;
 import org.junit.Assert;
 import org.junit.Test;
+
+import com.typesafe.config.Config;
 
 import java.io.File;
 import java.util.Arrays;
@@ -38,12 +41,14 @@ import java.util.List;
  */
 public class SchemaOrderingTest {
 
+  Config testconfig = StreamsConfigurator.getConfig().getConfig(SchemaOrderingTest.class.getSimpleName());
+
   @Test
   public void compareVerbParent() {
     SchemaStore schemaStore = new SchemaStoreImpl();
-    File update = new File("target/test-classes/activitystreams-schemas/verbs/update.json");
+    File update = new File(testconfig.getString("updateSchema"));
     schemaStore.create(update.toURI());
-    File activity = new File("target/test-classes/activitystreams-schemas/activity.json");
+    File activity = new File(testconfig.getString("activitySchema"));
     schemaStore.create(activity.toURI());
     assert (schemaStore.compare( schemaStore.getByUri(update.toURI()).get(), schemaStore.getByUri(activity.toURI()).get()) == 1);
     Iterator<Schema> schemaIterator = schemaStore.getSchemaIterator();
@@ -59,9 +64,9 @@ public class SchemaOrderingTest {
   @Test
   public void compareObjectTypeParent() {
     SchemaStore schemaStore = new SchemaStoreImpl();
-    File alert = new File("target/test-classes/activitystreams-schemas/objectTypes/alert.json");
+    File alert = new File(testconfig.getString("alertSchema"));
     schemaStore.create(alert.toURI());
-    File object = new File("target/test-classes/activitystreams-schemas/object.json");
+    File object = new File(testconfig.getString("objectSchema"));
     schemaStore.create(object.toURI());
     assert (schemaStore.compare( schemaStore.getByUri(object.toURI()).get(), schemaStore.getByUri(alert.toURI()).get()) == -1);
     Iterator<Schema> schemaIterator = schemaStore.getSchemaIterator();
@@ -77,9 +82,9 @@ public class SchemaOrderingTest {
   @Test
   public void compareUnrelated() {
     SchemaStore schemaStore = new SchemaStoreImpl();
-    File alert = new File("target/test-classes/activitystreams-schemas/objectTypes/alert.json");
+    File alert = new File(testconfig.getString("alertSchema"));
     schemaStore.create(alert.toURI());
-    File update = new File("target/test-classes/activitystreams-schemas/verbs/update.json");
+    File update = new File(testconfig.getString("objectSchema"));
     schemaStore.create(update.toURI());
     // update > alert b/c it's ascii is higher alphabetically
     assert (schemaStore.compare( schemaStore.getByUri(alert.toURI()).get(), schemaStore.getByUri(update.toURI()).get()) != 0);
@@ -88,9 +93,9 @@ public class SchemaOrderingTest {
   @Test
   public void compareVerbFieldRef() {
     SchemaStore schemaStore = new SchemaStoreImpl();
-    File update = new File("target/test-classes/activitystreams-schemas/verbs/update.json");
+    File update = new File(testconfig.getString("updateSchema"));
     schemaStore.create(update.toURI());
-    File object = new File("target/test-classes/activitystreams-schemas/object.json");
+    File object = new File(testconfig.getString("objectSchema"));
     schemaStore.create(object.toURI());
     assert ( schemaStore.compare( schemaStore.getByUri(update.toURI()).get(), schemaStore.getByUri(object.toURI()).get()) == 1);
     Iterator<Schema> schemaIterator = schemaStore.getSchemaIterator();
@@ -106,9 +111,9 @@ public class SchemaOrderingTest {
   @Test
   public void compareObjectTypeFieldRef() {
     SchemaStore schemaStore = new SchemaStoreImpl();
-    File alert = new File("target/test-classes/activitystreams-schemas/objectTypes/alert.json");
+    File alert = new File(testconfig.getString("alertSchema"));
     schemaStore.create(alert.toURI());
-    File mediaLink = new File("target/test-classes/activitystreams-schemas/media_link.json");
+    File mediaLink = new File(testconfig.getString("medialinkSchema"));
     schemaStore.create(mediaLink.toURI());
     assert ( schemaStore.compare( schemaStore.getByUri(mediaLink.toURI()).get(), schemaStore.getByUri(alert.toURI()).get()) == -1);
     Iterator<Schema> schemaIterator = schemaStore.getSchemaIterator();
@@ -125,9 +130,9 @@ public class SchemaOrderingTest {
   @Test
   public void compareVerbAncestorIndirect() {
     SchemaStore schemaStore = new SchemaStoreImpl();
-    File update = new File("target/test-classes/activitystreams-schemas/verbs/update.json");
+    File update = new File(testconfig.getString("updateSchema"));
     schemaStore.create(update.toURI());
-    File mediaLink = new File("target/test-classes/activitystreams-schemas/media_link.json");
+    File mediaLink = new File(testconfig.getString("medialinkSchema"));
     schemaStore.create(mediaLink.toURI());
     Assert.assertTrue(schemaStore.getByUri(mediaLink.toURI()).isPresent());
     Assert.assertTrue(schemaStore.getByUri(update.toURI()).isPresent());

--- a/streams-util/src/test/java/org/apache/streams/util/schema/test/SchemaStoreTest.java
+++ b/streams-util/src/test/java/org/apache/streams/util/schema/test/SchemaStoreTest.java
@@ -18,10 +18,12 @@
 
 package org.apache.streams.util.schema.test;
 
+import org.apache.streams.config.StreamsConfigurator;
 import org.apache.streams.util.schema.Schema;
 import org.apache.streams.util.schema.SchemaStore;
 import org.apache.streams.util.schema.SchemaStoreImpl;
 
+import com.typesafe.config.Config;
 import org.junit.Test;
 
 import java.io.File;
@@ -31,10 +33,12 @@ import java.io.File;
  */
 public class SchemaStoreTest {
 
+  Config testconfig = StreamsConfigurator.getConfig().getConfig(SchemaStoreTest.class.getSimpleName());
+
   @Test
   public void indexMediaLink() {
     SchemaStore schemaStore = new SchemaStoreImpl();
-    File file = new File("target/test-classes/activitystreams-schemas/media_link.json");
+    File file = new File(testconfig.getString("medialinkSchema"));
     schemaStore.create(file.toURI());
     assert ( schemaStore.getFileUriCount() == 1);
     assert ( schemaStore.getByUri(file.toURI()).isPresent());
@@ -44,7 +48,7 @@ public class SchemaStoreTest {
   @Test
   public void indexApprove() {
     SchemaStore schemaStore = new SchemaStoreImpl();
-    File file = new File("target/test-classes/activitystreams-schemas/verbs/approve.json");
+    File file = new File(testconfig.getString("approveSchema"));
     schemaStore.create(file.toURI());
     assert ( schemaStore.getFileUriCount() == 4);
     assert ( schemaStore.getByUri(file.toURI()).isPresent());
@@ -54,7 +58,7 @@ public class SchemaStoreTest {
   @Test
   public void indexCollection() {
     SchemaStore schemaStore = new SchemaStoreImpl();
-    File file = new File("target/test-classes/activitystreams-schemas/collection.json");
+    File file = new File(testconfig.getString("collectionSchema"));
     schemaStore.create(file.toURI());
     assert ( schemaStore.getFileUriCount() == 3);
     assert ( schemaStore.getByUri(file.toURI()).isPresent());
@@ -66,14 +70,14 @@ public class SchemaStoreTest {
   @Test
   public void indexUpdate() {
     SchemaStore schemaStore = new SchemaStoreImpl();
-    File file = new File("target/test-classes/activitystreams-schemas/verbs/update.json");
+    File file = new File(testconfig.getString("updateSchema"));
     schemaStore.create(file.toURI());
     assert ( schemaStore.getFileUriCount() == 4);
     assert ( schemaStore.getByUri(file.toURI()).isPresent());
     assert ( schemaStore.getById(schemaStore.getByUri(file.toURI()).get().getId()).isPresent());
     Schema update = schemaStore.getByUri(file.toURI()).get();
     assert ( update.getParent() != null );
-    File parentFile = new File("target/test-classes/activitystreams-schemas/activity.json");
+    File parentFile = new File(testconfig.getString("activitySchema"));
     Schema parent = schemaStore.getByUri(parentFile.toURI()).get();
     assert ( parent != null );
     assert ( update.getParentUri().equals(parent.getUri()));


### PR DESCRIPTION
resolves STREAMS-487

Test data originating within modules, used in other modules, should be a stand-alone artifact.

Since schemas are used as test data also, added a zip artifact containing schemas also.

Required refactoring on all tests that were previously accessing files in the test classpath (target/test-classes)

Now when test data is sourced through dependency on an archive zip, that data is unpacked in target/dependency and accessed as a file rather than a resource.