### PR TITLE
STREAMS-639 Upgrade jackson to at least 2.9.8 to address CVEs 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -371,7 +371,7 @@
         <guava.version>20.0</guava.version>
         <httpcomponents.core.version>4.4.8</httpcomponents.core.version>
         <httpcomponents.client.version>4.5.4</httpcomponents.client.version>
-        <jackson.version>2.9.5</jackson.version>
+        <jackson.version>2.9.8</jackson.version>
         <joda-time.version>2.9.9</joda-time.version>
         <joda-convert.version>1.8.1</joda-convert.version>
         <json-flattener.version>0.5.0</json-flattener.version>

--- a/streams-plugins/streams-plugin-pojo/src/test/resources/streams-plugin-pojo/pom.xml
+++ b/streams-plugins/streams-plugin-pojo/src/test/resources/streams-plugin-pojo/pom.xml
@@ -29,8 +29,8 @@
     <name>Test StreamsPojoMojo</name>
 
     <properties>
-        <jackson.version>2.6.1</jackson.version>
-        <juneau.version>7.0.1</juneau.version>
+        <jackson.version>2.9.8</jackson.version>
+        <juneau.version>7.2.1</juneau.version>
         <commons-lang3.version>3.4</commons-lang3.version>
     </properties>
 


### PR DESCRIPTION
resolves STREAMS-639 Upgrade jackson to at least 2.9.8 to address CVEs affecting >= 2.9.0, < 2.9.8