### PR TITLE
STREAMS-660: Fixup release 0.6.2-SNAPSHOT version strings in poms

### DIFF
--- a/.github/workflows/streams-ci-workflow.yml
+++ b/.github/workflows/streams-ci-workflow.yml
@@ -1,20 +1,63 @@
-name: build 
+name: build
 
-on: [push, pull_request]
+on:
+  push:
+    branches: ['master', 'STREAMS-*']
+  pull_request:
+    branches: ['master', 'STREAMS-*']
+  schedule:
+    # Run daily at 3pm UTC
+    - cron: '0 15 * * *'
 
 jobs:
   ubuntu-java-1-8:
-    timeout-minutes: 30
+    timeout-minutes: 60
     runs-on: ubuntu-latest
     name: Ubuntu - Java 1.8
     steps:
-      - name: checkout apache/streams.git
+      - name: Checkout apache/streams.git
         uses: actions/checkout@v2
-      - name: setup java 1.8
+      - name: Set up Java 1.8
         uses: actions/setup-java@v1.3.0
         with:
           java-version: 1.8
-      - name: mvn -B clean install -ff
+      - name: Restore ~/.m2/repository
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/
+            !~/.m2/repository/org/apache/streams
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: mvn -B -V clean install -ff -ntp
         env:
-          MAVEN_OPTS: -Xmx1g -XX:ReservedCodeCacheSize=1g -XX:+UseG1GC -Dorg.slf4j.simpleLogger.defaultLogLevel=WARN
-        run: mvn -B clean install -ff
+          MAVEN_OPTS: -Xmx1g -XX:ReservedCodeCacheSize=1g -XX:+UseG1GC -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+        run: mvn -B -V clean install -ff -ntp
+  macos-java-1-8:
+    timeout-minutes: 60
+    runs-on: macos-latest
+    name: macOS - Java 1.8
+    steps:
+      - name: Get system hardware info 
+        run: |
+          system_profiler -detailLevel mini SPHardwareDataType
+      - name: Checkout apache/streams.git
+        uses: actions/checkout@v2
+      - name: Set up Java 1.8
+        uses: actions/setup-java@v1.3.0
+        with:
+          java-version: 1.8
+      - name: Restore ~/.m2/repository
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.m2/repository/
+            !~/.m2/repository/org/apache/streams
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: mvn -B -V clean install -ff -ntp
+        env:
+          MAVEN_OPTS: -Xmx1g -XX:ReservedCodeCacheSize=1g -XX:+UseG1GC -Dorg.slf4j.simpleLogger.defaultLogLevel=INFO
+        run: mvn -B -V clean install -ff -ntp

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.apache.streams</groupId>
     <artifactId>apache-streams</artifactId>
-    <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
 
     <name>Apache Streams</name>
     <description>Apache Streams</description>
@@ -314,7 +314,7 @@
         <maven.javadoc.failOnError>false</maven.javadoc.failOnError>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <streams.version>0.6.1-SNAPSHOT</streams.version>
+        <streams.version>0.6.2-SNAPSHOT</streams.version>
         <github.global.server>github</github.global.server>
 
         <!-- Release Properties -->

--- a/streams-cli/pom.xml
+++ b/streams-cli/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apache-streams</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-components/pom.xml
+++ b/streams-components/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apache-streams</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-components/streams-converters/pom.xml
+++ b/streams-components/streams-converters/pom.xml
@@ -20,12 +20,12 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>streams-converters</artifactId>
-    <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
 
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-components</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/streams-components/streams-filters/pom.xml
+++ b/streams-components/streams-filters/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-components</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/streams-components/streams-http/pom.xml
+++ b/streams-components/streams-http/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-components</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/streams-config/pom.xml
+++ b/streams-config/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>apache-streams</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-config</artifactId>

--- a/streams-contrib/pom.xml
+++ b/streams-contrib/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>apache-streams</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-contrib</artifactId>

--- a/streams-contrib/streams-amazon-aws/pom.xml
+++ b/streams-contrib/streams-amazon-aws/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-amazon-aws/streams-persist-kinesis/pom.xml
+++ b/streams-contrib/streams-amazon-aws/streams-persist-kinesis/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>streams-amazon-aws</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-amazon-aws/streams-persist-s3/pom.xml
+++ b/streams-contrib/streams-amazon-aws/streams-persist-s3/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>streams-amazon-aws</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-cassandra/pom.xml
+++ b/streams-contrib/streams-persist-cassandra/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-console/pom.xml
+++ b/streams-contrib/streams-persist-console/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-elasticsearch/pom.xml
+++ b/streams-contrib/streams-persist-elasticsearch/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-filebuffer/pom.xml
+++ b/streams-contrib/streams-persist-filebuffer/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-graph/pom.xml
+++ b/streams-contrib/streams-persist-graph/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-hbase/pom.xml
+++ b/streams-contrib/streams-persist-hbase/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-hdfs/pom.xml
+++ b/streams-contrib/streams-persist-hdfs/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-kafka/pom.xml
+++ b/streams-contrib/streams-persist-kafka/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-mongo/pom.xml
+++ b/streams-contrib/streams-persist-mongo/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-neo4j/pom.xml
+++ b/streams-contrib/streams-persist-neo4j/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-persist-riak/pom.xml
+++ b/streams-contrib/streams-persist-riak/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-processor-fullcontact/pom.xml
+++ b/streams-contrib/streams-processor-fullcontact/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-processor-fullcontact</artifactId>

--- a/streams-contrib/streams-processor-jackson/pom.xml
+++ b/streams-contrib/streams-processor-jackson/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-processor-jackson</artifactId>

--- a/streams-contrib/streams-processor-json/pom.xml
+++ b/streams-contrib/streams-processor-json/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-processor-json</artifactId>

--- a/streams-contrib/streams-processor-peopledatalabs/pom.xml
+++ b/streams-contrib/streams-processor-peopledatalabs/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-processor-peopledatalabs</artifactId>

--- a/streams-contrib/streams-processor-peoplepattern/pom.xml
+++ b/streams-contrib/streams-processor-peoplepattern/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-processor-peoplepattern</artifactId>

--- a/streams-contrib/streams-processor-pipl/pom.xml
+++ b/streams-contrib/streams-processor-pipl/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-processor-pipl</artifactId>

--- a/streams-contrib/streams-processor-regex/pom.xml
+++ b/streams-contrib/streams-processor-regex/pom.xml
@@ -25,7 +25,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-processor-regex</artifactId>

--- a/streams-contrib/streams-processor-thedatagroup/pom.xml
+++ b/streams-contrib/streams-processor-thedatagroup/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-processor-thedatagroup</artifactId>

--- a/streams-contrib/streams-processor-urls/pom.xml
+++ b/streams-contrib/streams-processor-urls/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-processor-urls</artifactId>

--- a/streams-contrib/streams-provider-facebook/pom.xml
+++ b/streams-contrib/streams-provider-facebook/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>streams-contrib</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-provider-facebook</artifactId>

--- a/streams-contrib/streams-provider-google/google-gmail/pom.xml
+++ b/streams-contrib/streams-provider-google/google-gmail/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-provider-google</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-provider-google-gmail</artifactId>

--- a/streams-contrib/streams-provider-google/google-gplus/pom.xml
+++ b/streams-contrib/streams-provider-google/google-gplus/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-provider-google</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-provider-google-gplus</artifactId>

--- a/streams-contrib/streams-provider-google/pom.xml
+++ b/streams-contrib/streams-provider-google/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-provider-google</artifactId>

--- a/streams-contrib/streams-provider-instagram/pom.xml
+++ b/streams-contrib/streams-provider-instagram/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-provider-instagram</artifactId>

--- a/streams-contrib/streams-provider-linkedin/pom.xml
+++ b/streams-contrib/streams-provider-linkedin/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-moreover/pom.xml
+++ b/streams-contrib/streams-provider-moreover/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-provider-moreover</artifactId>

--- a/streams-contrib/streams-provider-rss/pom.xml
+++ b/streams-contrib/streams-provider-rss/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-provider-rss</artifactId>

--- a/streams-contrib/streams-provider-sprinklr/pom.xml
+++ b/streams-contrib/streams-provider-sprinklr/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-provider-sprinklr</artifactId>

--- a/streams-contrib/streams-provider-sysomos/pom.xml
+++ b/streams-contrib/streams-provider-sysomos/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-provider-sysomos</artifactId>

--- a/streams-contrib/streams-provider-twitter/pom.xml
+++ b/streams-contrib/streams-provider-twitter/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-contrib/streams-provider-youtube/pom.xml
+++ b/streams-contrib/streams-provider-youtube/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-contrib</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-core/pom.xml
+++ b/streams-core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>apache-streams</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-core</artifactId>

--- a/streams-dist/pom.xml
+++ b/streams-dist/pom.xml
@@ -22,7 +22,7 @@ under the License.
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>apache-streams</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/streams-examples/pom.xml
+++ b/streams-examples/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <artifactId>apache-streams</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <groupId>org.apache.streams.examples</groupId>
     <artifactId>streams-examples</artifactId>
-    <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
 
     <packaging>pom</packaging>
     <name>streams-examples</name>

--- a/streams-examples/streams-examples-flink/flink-twitter-collection/pom.xml
+++ b/streams-examples/streams-examples-flink/flink-twitter-collection/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams.examples</groupId>
         <artifactId>streams-examples-flink</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/streams-examples/streams-examples-flink/pom.xml
+++ b/streams-examples/streams-examples-flink/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>streams-examples</artifactId>
         <groupId>org.apache.streams.examples</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/streams-examples/streams-examples-local/elasticsearch-hdfs/pom.xml
+++ b/streams-examples/streams-examples-local/elasticsearch-hdfs/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams.examples</groupId>
         <artifactId>streams-examples-local</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/streams-examples/streams-examples-local/elasticsearch-reindex/pom.xml
+++ b/streams-examples/streams-examples-local/elasticsearch-reindex/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams.examples</groupId>
         <artifactId>streams-examples-local</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/streams-examples/streams-examples-local/mongo-elasticsearch-sync/pom.xml
+++ b/streams-examples/streams-examples-local/mongo-elasticsearch-sync/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams.examples</groupId>
         <artifactId>streams-examples-local</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/streams-examples/streams-examples-local/pom.xml
+++ b/streams-examples/streams-examples-local/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>streams-examples</artifactId>
         <groupId>org.apache.streams.examples</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/streams-examples/streams-examples-local/twitter-follow-neo4j/pom.xml
+++ b/streams-examples/streams-examples-local/twitter-follow-neo4j/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams.examples</groupId>
         <artifactId>streams-examples-local</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/streams-examples/streams-examples-local/twitter-history-elasticsearch/pom.xml
+++ b/streams-examples/streams-examples-local/twitter-history-elasticsearch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams.examples</groupId>
         <artifactId>streams-examples-local</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-examples/streams-examples-local/twitter-userstream-elasticsearch/pom.xml
+++ b/streams-examples/streams-examples-local/twitter-userstream-elasticsearch/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.apache.streams.examples</groupId>
         <artifactId>streams-examples-local</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-monitoring/pom.xml
+++ b/streams-monitoring/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>apache-streams</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-monitoring</artifactId>

--- a/streams-plugins/pom.xml
+++ b/streams-plugins/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>apache-streams</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/streams-plugins/streams-plugin-cassandra/pom.xml
+++ b/streams-plugins/streams-plugin-cassandra/pom.xml
@@ -21,13 +21,13 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>streams-plugin-cassandra</artifactId>
-    <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <parent>
         <groupId>org.apache.streams.plugins</groupId>
         <artifactId>streams-plugins</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/streams-plugins/streams-plugin-cassandra/src/test/resources/streams-plugin-cassandra/pom.xml
+++ b/streams-plugins/streams-plugin-cassandra/src/test/resources/streams-plugin-cassandra/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.apache.streams.plugins</groupId>
     <artifactId>streams-plugin-cassandra-test</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Test StreamsCassandraResourceGeneratorMojo</name>
 
@@ -99,7 +99,7 @@
             <plugin>
                 <groupId>org.apache.streams.plugins</groupId>
                 <artifactId>streams-plugin-cassandra</artifactId>
-                <version>0.6.1-SNAPSHOT</version>
+                <version>0.6.2-SNAPSHOT</version>
                 <configuration>
                     <sourcePaths>
                         <sourcePath>target/dependency/jsonschemaorg-schemas</sourcePath>

--- a/streams-plugins/streams-plugin-elasticsearch/pom.xml
+++ b/streams-plugins/streams-plugin-elasticsearch/pom.xml
@@ -21,13 +21,13 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>streams-plugin-elasticsearch</artifactId>
-    <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <parent>
         <groupId>org.apache.streams.plugins</groupId>
         <artifactId>streams-plugins</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/streams-plugins/streams-plugin-elasticsearch/src/test/resources/streams-plugin-elasticsearch/pom.xml
+++ b/streams-plugins/streams-plugin-elasticsearch/src/test/resources/streams-plugin-elasticsearch/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.apache.streams.plugins</groupId>
     <artifactId>streams-plugin-elasticsearch-test</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Test StreamsElasticsearchResourceGeneratorMojo</name>
 
@@ -99,7 +99,7 @@
             <plugin>
                 <groupId>org.apache.streams.plugins</groupId>
                 <artifactId>streams-plugin-elasticsearch</artifactId>
-                <version>0.6.1-SNAPSHOT</version>
+                <version>0.6.2-SNAPSHOT</version>
                 <configuration>
                     <sourcePaths>
                         <sourcePath>target/dependency/jsonschemaorg-schemas</sourcePath>

--- a/streams-plugins/streams-plugin-hbase/pom.xml
+++ b/streams-plugins/streams-plugin-hbase/pom.xml
@@ -21,13 +21,13 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>streams-plugin-hbase</artifactId>
-    <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <parent>
         <groupId>org.apache.streams.plugins</groupId>
         <artifactId>streams-plugins</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/streams-plugins/streams-plugin-hbase/src/test/resources/streams-plugin-hbase/pom.xml
+++ b/streams-plugins/streams-plugin-hbase/src/test/resources/streams-plugin-hbase/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.apache.streams.plugins</groupId>
     <artifactId>streams-plugin-hbase-test</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Test StreamsHbaseResourceGeneratorMojo</name>
 
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>org.apache.streams.plugins</groupId>
                 <artifactId>streams-plugin-hbase</artifactId>
-                <version>0.6.1-SNAPSHOT</version>
+                <version>0.6.2-SNAPSHOT</version>
                 <configuration>
                     <sourcePaths>
                         <sourcePath>target/dependency/jsonschemaorg-schemas</sourcePath>

--- a/streams-plugins/streams-plugin-hive/pom.xml
+++ b/streams-plugins/streams-plugin-hive/pom.xml
@@ -21,13 +21,13 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>streams-plugin-hive</artifactId>
-    <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <parent>
         <groupId>org.apache.streams.plugins</groupId>
         <artifactId>streams-plugins</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/streams-plugins/streams-plugin-hive/src/test/resources/streams-plugin-hive/pom.xml
+++ b/streams-plugins/streams-plugin-hive/src/test/resources/streams-plugin-hive/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.apache.streams.plugins</groupId>
     <artifactId>streams-plugin-hive-test</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Test StreamsPojoHiveMojo</name>
 
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>org.apache.streams.plugins</groupId>
                 <artifactId>streams-plugin-hive</artifactId>
-                <version>0.6.1-SNAPSHOT</version>
+                <version>0.6.2-SNAPSHOT</version>
                 <configuration>
                     <sourcePaths>
                         <sourcePath>target/dependency/jsonschemaorg-schemas</sourcePath>

--- a/streams-plugins/streams-plugin-pig/pom.xml
+++ b/streams-plugins/streams-plugin-pig/pom.xml
@@ -21,13 +21,13 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>streams-plugin-pig</artifactId>
-    <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <parent>
         <groupId>org.apache.streams.plugins</groupId>
         <artifactId>streams-plugins</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/streams-plugins/streams-plugin-pig/src/test/resources/streams-plugin-pig/pom.xml
+++ b/streams-plugins/streams-plugin-pig/src/test/resources/streams-plugin-pig/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.apache.streams.plugins</groupId>
     <artifactId>streams-plugin-pig-test</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Test StreamsPigResourceGeneratorMojo</name>
 
@@ -100,7 +100,7 @@
             <plugin>
                 <groupId>org.apache.streams.plugins</groupId>
                 <artifactId>streams-plugin-pig</artifactId>
-                <version>0.6.1-SNAPSHOT</version>
+                <version>0.6.2-SNAPSHOT</version>
                 <configuration>
                     <sourcePaths>
                         <sourcePath>target/dependency/jsonschemaorg-schemas</sourcePath>

--- a/streams-plugins/streams-plugin-pojo/pom.xml
+++ b/streams-plugins/streams-plugin-pojo/pom.xml
@@ -21,13 +21,13 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>streams-plugin-pojo</artifactId>
-    <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <parent>
         <groupId>org.apache.streams.plugins</groupId>
         <artifactId>streams-plugins</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/streams-plugins/streams-plugin-pojo/src/test/resources/streams-plugin-pojo/pom.xml
+++ b/streams-plugins/streams-plugin-pojo/src/test/resources/streams-plugin-pojo/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.apache.streams.plugins</groupId>
     <artifactId>streams-plugin-pojo-test</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Test StreamsPojoMojo</name>
 

--- a/streams-plugins/streams-plugin-scala/pom.xml
+++ b/streams-plugins/streams-plugin-scala/pom.xml
@@ -21,13 +21,13 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>streams-plugin-scala</artifactId>
-    <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>maven-plugin</packaging>
 
     <parent>
         <groupId>org.apache.streams.plugins</groupId>
         <artifactId>streams-plugins</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/streams-plugins/streams-plugin-scala/src/test/resources/streams-plugin-scala/pom.xml
+++ b/streams-plugins/streams-plugin-scala/src/test/resources/streams-plugin-scala/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.apache.streams.plugins</groupId>
     <artifactId>streams-plugin-scala-test</artifactId>
-    <version>0.6.1-SNAPSHOT</version>
+    <version>0.6.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>Test StreamsPojoScalaMojo</name>
 
@@ -99,7 +99,7 @@
             <plugin>
                 <groupId>org.apache.streams.plugins</groupId>
                 <artifactId>streams-plugin-scala</artifactId>
-                <version>0.6.1-SNAPSHOT</version>
+                <version>0.6.2-SNAPSHOT</version>
                 <configuration>
                     <packages>org.apache.streams.pojo.json</packages>
                     <target>target/generated-sources/scala-mojo</target>

--- a/streams-pojo-extensions/pom.xml
+++ b/streams-pojo-extensions/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>apache-streams</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/streams-pojo/pom.xml
+++ b/streams-pojo/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>apache-streams</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/streams-runtimes/pom.xml
+++ b/streams-runtimes/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>apache-streams</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-runtimes</artifactId>

--- a/streams-runtimes/streams-runtime-local/pom.xml
+++ b/streams-runtimes/streams-runtime-local/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-runtimes</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-runtime-local</artifactId>

--- a/streams-schemas/pom.xml
+++ b/streams-schemas/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>apache-streams</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-schemas</artifactId>

--- a/streams-schemas/streams-schema-activitystreams/pom.xml
+++ b/streams-schemas/streams-schema-activitystreams/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-schemas</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-schema-activitystreams</artifactId>

--- a/streams-schemas/streams-schema-activitystreams/src/test/java/org/w3c/activitystreams/test/SchemaValidationTest.java
+++ b/streams-schemas/streams-schema-activitystreams/src/test/java/org/w3c/activitystreams/test/SchemaValidationTest.java
@@ -66,18 +66,18 @@ public class SchemaValidationTest {
     for (String file : files) {
       if ( !file.startsWith(".") ) {
 
-        LOGGER.info("Test File: activities/" + file);
+        LOGGER.debug("Test File: activities/" + file);
         String testFileString = new String(Files.readAllBytes(Paths.get("target/test-classes/activities/" + file)));
-        LOGGER.info("Test Document JSON: " + testFileString);
+        LOGGER.debug("Test Document JSON: " + testFileString);
         JsonNode testNode = MAPPER.readValue(testFileString, ObjectNode.class);
-        LOGGER.info("Test Document Object:" + testNode);
-        LOGGER.info("Test Schema File: " + "target/classes/verbs/" + file);
+        LOGGER.debug("Test Document Object:" + testNode);
+        LOGGER.debug("Test Schema File: " + "target/classes/verbs/" + file);
         String testSchemaString = new String(Files.readAllBytes(Paths.get("target/classes/verbs/" + file)));
-        LOGGER.info("Test Schema JSON: " + testSchemaString);
+        LOGGER.debug("Test Schema JSON: " + testSchemaString);
         JsonNode testSchemaNode = MAPPER.readValue(testFileString, ObjectNode.class);
-        LOGGER.info("Test Schema Object:" + testSchemaNode);
+        LOGGER.debug("Test Schema Object:" + testSchemaNode);
         JsonSchema testSchema = factory.getSchema(testSchemaNode);
-        LOGGER.info("Test Schema:" + testSchema);
+        LOGGER.debug("Test Schema:" + testSchema);
 
         Set<ValidationMessage> errors = testSchema.validate(testNode);
         assertThat(errors.size(), is(0));

--- a/streams-schemas/streams-schema-activitystreams2/pom.xml
+++ b/streams-schemas/streams-schema-activitystreams2/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-schemas</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-schema-activitystreams2</artifactId>

--- a/streams-schemas/streams-schema-jsonschemaorg/pom.xml
+++ b/streams-schemas/streams-schema-jsonschemaorg/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>streams-schemas</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>streams-schema-jsonschemaorg</artifactId>

--- a/streams-testing/pom.xml
+++ b/streams-testing/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apache-streams</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-util/pom.xml
+++ b/streams-util/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>apache-streams</artifactId>
         <groupId>org.apache.streams</groupId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/streams-verbs/pom.xml
+++ b/streams-verbs/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.apache.streams</groupId>
         <artifactId>apache-streams</artifactId>
-        <version>0.6.2-SNAPSHOT-SNAPSHOT</version>
+        <version>0.6.2-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
This fixes the SNAPSHOT release version in all of the poms and makes a couple other minor changes,  adding MacOS and a daily build to the build workflow and changing the log level to debug on `SchemaValidationTest`.