### PR TITLE
Remove ex.printStackTrace() invocation

### DIFF
--- a/streams-contrib/streams-amazon-aws/streams-persist-s3/src/main/java/org/apache/streams/s3/S3OutputStreamWrapper.java
+++ b/streams-contrib/streams-amazon-aws/streams-persist-s3/src/main/java/org/apache/streams/s3/S3OutputStreamWrapper.java
@@ -102,8 +102,7 @@ public class S3OutputStreamWrapper extends OutputStream {
         this.outputStream.close();
         this.outputStream = null;
       } catch (Exception ex) {
-        ex.printStackTrace();
-        LOGGER.warn("There was an error adding the temporaryFile to S3");
+        LOGGER.warn("There was an error adding the temporaryFile to S3", ex);
       } finally {
         // we are done here.
         this.isClosed = true;


### PR DESCRIPTION
This sends the stack trace of an exception to the logger instead of stdout.