### PR TITLE
Fix build-helper-maven-plugin add-source directory config

### DIFF
--- a/streams-contrib/streams-processor-peoplepattern/pom.xml
+++ b/streams-contrib/streams-processor-peoplepattern/pom.xml
@@ -104,7 +104,7 @@
                             </goals>
                             <configuration>
                                 <sources>
-                                    <source>target/generated-sources/jsonschema2pojo/**/*.java</source>
+                                    <source>target/generated-sources/jsonschema2pojo</source>
                                 </sources>
                             </configuration>
                         </execution>


### PR DESCRIPTION
I think the source configuration is wrong. I'm not sure how exactly to test this change though.

IntelliJ says
Illegal char <*> at index 41: target/generated-sources/jsonschema2pojo/**/*.java
when I try to sync the project with the IDE.